### PR TITLE
Update genfs_contexts

### DIFF
--- a/sepolicy/vendor/genfs_contexts
+++ b/sepolicy/vendor/genfs_contexts
@@ -1,3 +1,6 @@
+# LED
+genfscon sysfs /devices/platform/soc/c440000.qcom,spmi/spmi-0/spmi0-05/c440000.qcom,spmi:qcom,pm6150l@5:qcom,wled@d800/backlight/backlight/brightness                                   u:object_r:sysfs_leds:s0
+
 # Vibrator
 genfscon sysfs /devices/platform/soc/990000.i2c/i2c-2/2-005a/leds/vibrator_aw8695                                                                                                       u:object_r:sysfs_leds:s0
 
@@ -25,4 +28,3 @@ genfscon sysfs /devices/platform/soc/soc:qcom,smp2p-cdsp/wakeup                 
 genfscon sysfs /devices/platform/soc/soc:qcom,smp2p-mpss/wakeup                                                                                                                         u:object_r:sysfs_wakeup:s0
 genfscon sysfs /devices/platform/soc/soc:qcom,smp2p-npu/wakeup                                                                                                                          u:object_r:sysfs_wakeup:s0
 genfscon sysfs /devices/platform/soc/soc:qcom,smp2p_sleepstate/wakeup                                                                                                                   u:object_r:sysfs_wakeup:s0
-

--- a/sepolicy/vendor/hal_sensors_default.te
+++ b/sepolicy/vendor/hal_sensors_default.te
@@ -1,0 +1,1 @@
+allow hal_sensors_default sysfs_leds:file r_file_perms;


### PR DESCRIPTION
Fix issue where seLinux prevented `hal_sensors_default` from accessing backlight brightness.