### PR TITLE
Update config.xml: setting config_fingerprintWakeAndUnlock to "false", because FP4's sensor is embedded in the power key and listening all the time is annoying.

### DIFF
--- a/overlay/frameworks/base/packages/SystemUI/res/values/config.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values/config.xml
@@ -28,4 +28,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <resources>
     <!-- Enable doze mode -->
     <bool name="doze_display_state_supported">true</bool>
+    <!-- FP4's sensor is embedded in the power key and
+         listening all the time is annoying. -->
+    <bool name="config_fingerprintWakeAndUnlock">false</bool>
 </resources>


### PR DESCRIPTION
FP4's sensor is embedded in the power key and listening all the time is annoying.